### PR TITLE
Criação e Listagem de Usuário

### DIFF
--- a/infra/controller.js
+++ b/infra/controller.js
@@ -1,6 +1,7 @@
 import {
   InternalServerError,
   MethodNotAllowedError,
+  NotFoundError,
   ValidationError,
 } from "infra/errors";
 
@@ -11,7 +12,7 @@ function onNoMatchHandler(request, response) {
 }
 
 function onErrorHandler(error, request, response) {
-  if (error instanceof ValidationError) {
+  if (error instanceof ValidationError || error instanceof NotFoundError) {
     return response.status(error.statusCode).json(error);
   }
 

--- a/infra/controller.js
+++ b/infra/controller.js
@@ -1,4 +1,8 @@
-import { InternalServerError, MethodNotAllowedError } from "infra/errors";
+import {
+  InternalServerError,
+  MethodNotAllowedError,
+  ValidationError,
+} from "infra/errors";
 
 function onNoMatchHandler(request, response) {
   const publicErrorObject = new MethodNotAllowedError();
@@ -7,6 +11,10 @@ function onNoMatchHandler(request, response) {
 }
 
 function onErrorHandler(error, request, response) {
+  if (error instanceof ValidationError) {
+    return response.status(error.statusCode).json(error);
+  }
+
   const publicErrorObject = new InternalServerError({
     cause: error,
     statusCode: error.statusCode,

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -85,6 +85,38 @@ export class ValidationError extends Error {
   }
 }
 
+export class NotFoundError extends Error {
+  constructor({ cause, message, action }) {
+    super(message || "Não foi possível encontrar esse recurso no sistema.", {
+      cause,
+    });
+
+    this.name = "NotFoundError";
+    this.action =
+      action || "Verifique se os parâmetros enviados na consulta estão certos.";
+    this.statusCode = 404;
+  }
+
+  /**
+   * SOBRESCREVER O COMPORTAMENTO QUANDO É PEDIDO PARA TRANSFORMAR
+   * ESSE OBJETO EM UM JSON. E PARA ISSO DECLARAMOS UM NOVO MÉTODO
+   * NESSA CLASSE CHAMADO toJSON(). E O QUE FOR DEVOLVIDO DENTRO,
+   * É O QUE VAI APARECER NO RESULTADO DO STRINGFY.
+   *
+   * this.name -> VAI RETORNAR O VALOR QUE FOI HERDADO, NESSE CASO
+   * 'Error'. MAS SE QUISERMOS DEFINIR 'InternalServerError' PRECISAMOS
+   * SOBRESCREVER ESSA PROPRIEDADE
+   */
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
 export class MethodNotAllowedError extends Error {
   constructor() {
     super("Método não permitido para este endpoint.");

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -56,6 +56,35 @@ export class ServiceError extends Error {
   }
 }
 
+export class ValidationError extends Error {
+  constructor({ cause, message, action }) {
+    super(message || "Um erro de validação ocorreu.", { cause });
+
+    this.name = "ValidationError";
+    this.action = action || "Ajuste os dados enviados e tente novamente.";
+    this.statusCode = 400;
+  }
+
+  /**
+   * SOBRESCREVER O COMPORTAMENTO QUANDO É PEDIDO PARA TRANSFORMAR
+   * ESSE OBJETO EM UM JSON. E PARA ISSO DECLARAMOS UM NOVO MÉTODO
+   * NESSA CLASSE CHAMADO toJSON(). E O QUE FOR DEVOLVIDO DENTRO,
+   * É O QUE VAI APARECER NO RESULTADO DO STRINGFY.
+   *
+   * this.name -> VAI RETORNAR O VALOR QUE FOI HERDADO, NESSE CASO
+   * 'Error'. MAS SE QUISERMOS DEFINIR 'InternalServerError' PRECISAMOS
+   * SOBRESCREVER ESSA PROPRIEDADE
+   */
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
 export class MethodNotAllowedError extends Error {
   constructor() {
     super("Método não permitido para este endpoint.");

--- a/infra/migrations/1770739415057_test-migration.js
+++ b/infra/migrations/1770739415057_test-migration.js
@@ -1,7 +1,0 @@
-/* eslint-disable camelcase */
-
-exports.shorthands = undefined;
-
-exports.up = (pgm) => {};
-
-exports.down = (pgm) => {};

--- a/infra/migrations/1774805009986_create-users.js
+++ b/infra/migrations/1774805009986_create-users.js
@@ -1,0 +1,44 @@
+exports.up = (pgm) => {
+  pgm.createTable("users", {
+    id: {
+      type: "uuid",
+      primaryKey: true,
+      default: pgm.func("gen_random_uuid()"),
+    },
+
+    // For reference, GitHub limits usernames to 39 characters.
+    username: {
+      type: "varchar(30)",
+      notNull: true,
+      unique: true,
+    },
+
+    // Why 254 in length? https://stackoverflow.com/a/1199238
+    email: {
+      type: "varchar(254)",
+      notNull: true,
+      unique: true,
+    },
+
+    // Why 60 length? https://www.npmjs.com/package/bcrypt#hash-info
+    password: {
+      type: "varchar(60)",
+      notNull: true,
+    },
+
+    // Why timestamp with timezone? https://justatheory.com/2012/04/postgres-use-timestamptz/
+    created_at: {
+      type: "timestamptz",
+      notNull: true,
+      default: pgm.func("timezone('utc', now())"),
+    },
+
+    updated_at: {
+      type: "timestamptz",
+      notNull: true,
+      default: pgm.func("timezone('utc', now())"),
+    },
+  });
+};
+
+exports.down = false;

--- a/models/migrator.js
+++ b/models/migrator.js
@@ -8,7 +8,7 @@ const defaultMigrationOptions = {
   dryRun: true,
   dir: resolve("infra", "migrations"),
   direction: "up",
-  verbose: true,
+  log: () => {},
   migrationsTable: "pgmigrations",
 };
 

--- a/models/user.js
+++ b/models/user.js
@@ -1,5 +1,36 @@
 import database from "infra/database";
-import { ValidationError } from "infra/errors";
+import { NotFoundError, ValidationError } from "infra/errors";
+
+async function findOneByUsername(username) {
+  const userFound = await runSelectQuery(username);
+
+  return userFound;
+
+  async function runSelectQuery(username) {
+    const results = await database.query({
+      text: `
+        SELECT
+          *
+        FROM
+          users
+        WHERE
+          LOWER(username) = LOWER($1)
+        LIMIT
+          1
+        ;`,
+      values: [username],
+    });
+
+    if (results.rowCount === 0) {
+      throw new NotFoundError({
+        message: "O username informado não foi encontrado no sistema.",
+        action: "Verifique se o username está digitado corretamente.",
+      });
+    }
+
+    return results.rows[0];
+  }
+}
 
 async function create(userInputValues) {
   await validateUniqueEmail(userInputValues.email);
@@ -40,7 +71,7 @@ async function create(userInputValues) {
           users
         WHERE
           LOWER(username) = LOWER($1)
-      ;`,
+        ;`,
       values: [username],
     });
 
@@ -61,7 +92,7 @@ async function create(userInputValues) {
           ($1, $2, $3)
         RETURNING
           *
-      ;`,
+        ;`,
       values: [
         userInputValues.username,
         userInputValues.email,
@@ -75,6 +106,7 @@ async function create(userInputValues) {
 
 const user = {
   create,
+  findOneByUsername,
 };
 
 export default user;

--- a/models/user.js
+++ b/models/user.js
@@ -1,0 +1,80 @@
+import database from "infra/database";
+import { ValidationError } from "infra/errors";
+
+async function create(userInputValues) {
+  await validateUniqueEmail(userInputValues.email);
+
+  await validateUniqueUsername(userInputValues.username);
+
+  const newUser = await runInsertQuery(userInputValues);
+
+  return newUser;
+
+  async function validateUniqueEmail(email) {
+    const results = await database.query({
+      text: `
+        SELECT
+          email
+        FROM
+          users
+        WHERE
+          LOWER(email) = LOWER($1)
+      ;`,
+      values: [email],
+    });
+
+    if (results.rowCount > 0) {
+      throw new ValidationError({
+        message: "O email informado já está sendo utilizado.",
+        action: "Utilize outro email para realizar o cadastro.",
+      });
+    }
+  }
+
+  async function validateUniqueUsername(username) {
+    const results = await database.query({
+      text: `
+        SELECT
+          email
+        FROM
+          users
+        WHERE
+          LOWER(username) = LOWER($1)
+      ;`,
+      values: [username],
+    });
+
+    if (results.rowCount > 0) {
+      throw new ValidationError({
+        message: "O username informado já está sendo utilizado.",
+        action: "Utilize outro username para realizar o cadastro.",
+      });
+    }
+  }
+
+  async function runInsertQuery(userInputValues) {
+    const results = await database.query({
+      text: `
+        INSERT INTO
+          users (username, email, password)
+        VALUES
+          ($1, $2, $3)
+        RETURNING
+          *
+      ;`,
+      values: [
+        userInputValues.username,
+        userInputValues.email,
+        userInputValues.password,
+      ],
+    });
+
+    return results.rows[0];
+  }
+}
+
+const user = {
+  create,
+};
+
+export default user;

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "pg": "8.12.0",
         "react": "18.3.1",
         "react-dom": "18.3.1",
-        "swr": "2.2.5"
+        "swr": "2.2.5",
+        "uuid": "11.1.0"
       },
       "devDependencies": {
         "@commitlint/config-conventional": "19.2.2",
@@ -11559,6 +11560,19 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "pg": "8.12.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "swr": "2.2.5"
+    "swr": "2.2.5",
+    "uuid": "11.1.0"
   },
   "devDependencies": {
     "@commitlint/config-conventional": "19.2.2",

--- a/pages/api/v1/users/[username]/index.js
+++ b/pages/api/v1/users/[username]/index.js
@@ -1,0 +1,19 @@
+import { createRouter } from "next-connect";
+
+import controller from "infra/controller";
+
+import user from "models/user";
+
+const router = createRouter();
+
+router.get(getHandler);
+
+export default router.handler(controller.errorHandlers);
+
+async function getHandler(request, response) {
+  const username = request.query.username;
+
+  const userFound = await user.findOneByUsername(username);
+
+  return response.status(200).json(userFound);
+}

--- a/pages/api/v1/users/index.js
+++ b/pages/api/v1/users/index.js
@@ -1,0 +1,19 @@
+import { createRouter } from "next-connect";
+
+import controller from "infra/controller";
+
+import user from "models/user";
+
+const router = createRouter();
+
+router.post(postHandler);
+
+export default router.handler(controller.errorHandlers);
+
+async function postHandler(request, response) {
+  const userInputValues = request.body;
+
+  const newUser = await user.create(userInputValues);
+
+  return response.status(201).json(newUser);
+}

--- a/tests/integration/api/v1/migrations/post.test.js
+++ b/tests/integration/api/v1/migrations/post.test.js
@@ -7,32 +7,38 @@ beforeAll(async () => {
 
 describe("POST /api/v1/migrations", () => {
   describe("Anonymous user", () => {
-    describe("Running pending migrations", () => {});
+    describe("Running pending migrations", () => {
+      test("For the first time", async () => {
+        const response1 = await fetch(
+          "http://localhost:3000/api/v1/migrations",
+          {
+            method: "POST",
+          },
+        );
 
-    test("For the first time", async () => {
-      const response1 = await fetch("http://localhost:3000/api/v1/migrations", {
-        method: "POST",
+        expect(response1.status).toBe(201);
+
+        const response1Body = await response1.json();
+
+        expect(Array.isArray(response1Body)).toBe(true);
+        expect(response1Body.length).toBeGreaterThan(0);
       });
 
-      expect(response1.status).toBe(201);
+      test("For second time", async () => {
+        const response2 = await fetch(
+          "http://localhost:3000/api/v1/migrations",
+          {
+            method: "POST",
+          },
+        );
 
-      const response1Body = await response1.json();
+        expect(response2.status).toBe(200);
 
-      expect(Array.isArray(response1Body)).toBe(true);
-      expect(response1Body.length).toBeGreaterThan(0);
-    });
+        const response2Body = await response2.json();
 
-    test("For second time", async () => {
-      const response2 = await fetch("http://localhost:3000/api/v1/migrations", {
-        method: "POST",
+        expect(Array.isArray(response2Body)).toBe(true);
+        expect(response2Body.length).toBe(0);
       });
-
-      expect(response2.status).toBe(200);
-
-      const response2Body = await response2.json();
-
-      expect(Array.isArray(response2Body)).toBe(true);
-      expect(response2Body.length).toBe(0);
     });
   });
 });

--- a/tests/integration/api/v1/users/[username]/get.test.js
+++ b/tests/integration/api/v1/users/[username]/get.test.js
@@ -1,0 +1,104 @@
+import { version as uuidVersion } from "uuid";
+
+import orchestrator from "tests/orchestrator";
+
+beforeAll(async () => {
+  await orchestrator.waitForServices();
+  await orchestrator.clearDatabase();
+  await orchestrator.runPendingMigrations();
+});
+
+describe("GET /api/v1/users/[username]", () => {
+  describe("Anonymous user", () => {
+    test("With exact case match", async () => {
+      const response1 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "MesmoCase",
+          email: "mesmo.case@test.com",
+          password: "senha123",
+        }),
+      });
+
+      expect(response1.status).toBe(201);
+
+      const response2 = await fetch(
+        "http://localhost:3000/api/v1/users/MesmoCase",
+      );
+
+      expect(response2.status).toBe(200);
+
+      const response2Body = await response2.json();
+
+      expect(response2Body).toEqual({
+        id: response2Body.id,
+        username: "MesmoCase",
+        email: "mesmo.case@test.com",
+        password: "senha123",
+        created_at: response2Body.created_at,
+        updated_at: response2Body.updated_at,
+      });
+
+      expect(uuidVersion(response2Body.id)).toBe(4);
+      expect(Date.parse(response2Body.created_at)).not.toBeNaN();
+      expect(Date.parse(response2Body.updated_at)).not.toBeNaN();
+    });
+
+    test("With case mismatch", async () => {
+      const response1 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "CaseDiferente",
+          email: "case.diferente@test.com",
+          password: "senha123",
+        }),
+      });
+
+      expect(response1.status).toBe(201);
+
+      const response2 = await fetch(
+        "http://localhost:3000/api/v1/users/casediferente",
+      );
+
+      expect(response2.status).toBe(200);
+
+      const response2Body = await response2.json();
+
+      expect(response2Body).toEqual({
+        id: response2Body.id,
+        username: "CaseDiferente",
+        email: "case.diferente@test.com",
+        password: "senha123",
+        created_at: response2Body.created_at,
+        updated_at: response2Body.updated_at,
+      });
+
+      expect(uuidVersion(response2Body.id)).toBe(4);
+      expect(Date.parse(response2Body.created_at)).not.toBeNaN();
+      expect(Date.parse(response2Body.updated_at)).not.toBeNaN();
+    });
+
+    test("With nonexistent username", async () => {
+      const response = await fetch(
+        "http://localhost:3000/api/v1/users/UsuarioInexistente",
+      );
+
+      expect(response.status).toBe(404);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "NotFoundError",
+        message: "O username informado não foi encontrado no sistema.",
+        action: "Verifique se o username está digitado corretamente.",
+        status_code: 404,
+      });
+    });
+  });
+});

--- a/tests/integration/api/v1/users/post.test.js
+++ b/tests/integration/api/v1/users/post.test.js
@@ -1,4 +1,5 @@
-import database from "infra/database";
+import { version as uuidVersion } from "uuid";
+
 import orchestrator from "tests/orchestrator";
 
 beforeAll(async () => {
@@ -10,19 +11,112 @@ beforeAll(async () => {
 describe("POST /api/v1/users", () => {
   describe("Anonymous user", () => {
     test("With unique and valid data", async () => {
-      await database.query({
-        text: "INSERT INTO users (username, email, password) VALUES ($1, $2, $3);",
-        values: ["lubnimorais", "lubni.morais@gmail.com", "senha123"],
-      });
-
-      const users = await database.query("SELECT * FROM users;");
-      console.log(users.rows);
-
       const response = await fetch("http://localhost:3000/api/v1/users ", {
         method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "johndoe",
+          email: "johndoe@test.com",
+          password: "senha123",
+        }),
       });
 
       expect(response.status).toBe(201);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        id: responseBody.id,
+        username: "johndoe",
+        email: "johndoe@test.com",
+        password: "senha123",
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+      });
+
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
+    });
+
+    test("With duplicated 'email'", async () => {
+      const response1 = await fetch("http://localhost:3000/api/v1/users ", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "emailduplicado1",
+          email: "duplicado@test.com",
+          password: "senha123",
+        }),
+      });
+
+      expect(response1.status).toBe(201);
+
+      const response2 = await fetch("http://localhost:3000/api/v1/users ", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "emailduplicado2",
+          email: "Duplicado@test.com",
+          password: "senha123",
+        }),
+      });
+
+      expect(response2.status).toBe(400);
+
+      const response2Body = await response2.json();
+
+      expect(response2Body).toEqual({
+        name: "ValidationError",
+        message: "O email informado já está sendo utilizado.",
+        action: "Utilize outro email para realizar o cadastro.",
+        status_code: 400,
+      });
+    });
+
+    test("With duplicated 'username'", async () => {
+      const response1 = await fetch("http://localhost:3000/api/v1/users ", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "usernameduplicado",
+          email: "usernameduplicado1@test.com",
+          password: "senha123",
+        }),
+      });
+
+      expect(response1.status).toBe(201);
+
+      const response2 = await fetch("http://localhost:3000/api/v1/users ", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "UsernameDuplicado",
+          email: "usernameduplicado2@test.com",
+          password: "senha123",
+        }),
+      });
+
+      expect(response2.status).toBe(400);
+
+      const response2Body = await response2.json();
+
+      expect(response2Body).toEqual({
+        name: "ValidationError",
+        message: "O username informado já está sendo utilizado.",
+        action: "Utilize outro username para realizar o cadastro.",
+        status_code: 400,
+      });
     });
   });
 });

--- a/tests/integration/api/v1/users/post.test.js
+++ b/tests/integration/api/v1/users/post.test.js
@@ -1,0 +1,28 @@
+import database from "infra/database";
+import orchestrator from "tests/orchestrator";
+
+beforeAll(async () => {
+  await orchestrator.waitForServices();
+  await orchestrator.clearDatabase();
+  await orchestrator.runPendingMigrations();
+});
+
+describe("POST /api/v1/users", () => {
+  describe("Anonymous user", () => {
+    test("With unique and valid data", async () => {
+      await database.query({
+        text: "INSERT INTO users (username, email, password) VALUES ($1, $2, $3);",
+        values: ["lubnimorais", "lubni.morais@gmail.com", "senha123"],
+      });
+
+      const users = await database.query("SELECT * FROM users;");
+      console.log(users.rows);
+
+      const response = await fetch("http://localhost:3000/api/v1/users ", {
+        method: "POST",
+      });
+
+      expect(response.status).toBe(201);
+    });
+  });
+});

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -2,6 +2,8 @@ import retry from "async-retry";
 
 import database from "infra/database";
 
+import migrator from "models/migrator";
+
 // AGUARDAR POR TODOS OS SERVIÇOS ESTAREM PRONTOS
 async function waitForServices() {
   await waitForWebServer();
@@ -36,9 +38,14 @@ async function clearDatabase() {
   await database.query("drop schema public cascade; create schema public;");
 }
 
+async function runPendingMigrations() {
+  await migrator.runPendingMigrations();
+}
+
 const orchestrator = {
   waitForServices,
   clearDatabase,
+  runPendingMigrations,
 };
 
 export default orchestrator;


### PR DESCRIPTION
- Cria model `user`
- Cria 2 novos endpoints:
  - `POST` `/api/v1/users`
  - `GET` `/api/v1/users/[username]`
- Remove `migration` de teste
- Cria `migration` que cira a tabela `users`
- Cria dois novos erros customizados:
  - `ValidationError`
  - `NotFoundError`
- Adiciona novo método ao `orchestrator`:
  - `runPedingMigrations`
- Silencia os logs do `migrator`      